### PR TITLE
Small README.md change

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ On the new component panel, copy and paste the following attribute template into
   "location_id": "xyz213",
   "part_id": "mhj127",
   "app_api_key": "my_app_key",
-  "app_api_key_id": "my_api_key_id",
+  "app_api_key_id": "my_api_key_id"
 }
 ```
 


### PR DESCRIPTION
Remove trailing comma from last item in config JSON - when pasted into the Viam camera component “configure” box, causes a “SyntaxError: Expected double-quoted property name in JSON at position 419 (line 16 column 1)”